### PR TITLE
Use explicit string literals for id/beacon in nearobject clauses

### DIFF
--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -475,24 +475,24 @@ class TestNearObject(unittest.TestCase):
         near_object = NearObject({
             'id': 'test_id',
         })
-        self.assertEqual(str(near_object), 'nearObject: {id: test_id} ')
+        self.assertEqual(str(near_object), 'nearObject: {id: "test_id"} ')
 
         near_object = NearObject({
             'id': 'test_id',
             'certainty': 0.7
         })
-        self.assertEqual(str(near_object), 'nearObject: {id: test_id certainty: 0.7} ')
+        self.assertEqual(str(near_object), 'nearObject: {id: "test_id" certainty: 0.7} ')
 
         near_object = NearObject({
             'beacon': 'test_beacon',
         })
-        self.assertEqual(str(near_object), 'nearObject: {beacon: test_beacon} ')
+        self.assertEqual(str(near_object), 'nearObject: {beacon: "test_beacon"} ')
 
         near_object = NearObject({
             'beacon': 'test_beacon',
             'certainty': 0.0
         })
-        self.assertEqual(str(near_object), 'nearObject: {beacon: test_beacon certainty: 0.0} ')
+        self.assertEqual(str(near_object), 'nearObject: {beacon: "test_beacon" certainty: 0.0} ')
 
 
 class TestNearImage(unittest.TestCase):

--- a/test/gql/test_get.py
+++ b/test/gql/test_get.py
@@ -130,7 +130,7 @@ class TestGetBuilder(unittest.TestCase):
 
         # valid calls
         query = GetBuilder("Person", "name", None).with_near_object(near_object).build()
-        self.assertEqual('{Get{Person(nearObject: {id: test_id certainty: 0.55} ){name}}}', query)
+        self.assertEqual('{Get{Person(nearObject: {id: "test_id" certainty: 0.55} ){name}}}', query)
 
         # invalid calls
         near_error_msg = "Cannot use multiple 'near' filters, or a 'near' filter along with a 'ask' filter!"

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -263,7 +263,7 @@ class NearObject(Filter):
 
     def __str__(self):
 
-        near_object = f'nearObject: {{{self.obj_id}: {self._content[self.obj_id]}'
+        near_object = f'nearObject: {{{self.obj_id}: "{self._content[self.obj_id]}"'
         if 'certainty' in self._content:
             near_object += f' certainty: {self._content["certainty"]}'
         return near_object + '} '


### PR DESCRIPTION
When the `id` or `beacon` value is not put between quotes and a pure string is provided as value (e.g., `test_id`), i.e., without digits, the produced GraphQL query is fine. However, as soon as UUIDs are provided, as is relevant for `nearobject` clauses, these UUIDs are interpreted as numbers, and it breaks after the first dash.

Example:
```
client.query.get("Endpoint", [ "path" ]) \
    .with_near_object({ "id": "e5dc4a4c-ef0f-3aed-89a3-a73435c6bbcf" }) \
    .do()
```

Before, this would translate into the following GraphQL query:
```
{
  Get {
    Endpoint(nearObject: {id: e5dc4a4c-ef0f-3aed-89a3-a73435c6bbcf}) {
      path
    }
  }
}
```

This query features a syntax error, due to the UUID not being recognized as a String literal. This patch ensures that the produced GraphQL query looks like this:
```
{
  Get {
    Endpoint(nearObject: {id: "e5dc4a4c-ef0f-3aed-89a3-a73435c6bbcf"}) {
      path
    }
  }
}
```