### PR TITLE
v3.3.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 3.3.0
+-------------
+| This minor version adds a new :meth:`~weaviate.gql.get.GetBuilder.with_offset` for the ``Get`` queries. This method should be used 
+    with the :meth:`~weaviate.gql.get.GetBuilder.with_limit`. This new feature (introduced in weaviate version ``1.8.0``) allows to
+    use pagination functionality with the ``Get`` queries. The ``offset`` represents the start index of the objects to be returned,
+    and the number of objects is specified by the :meth:`~weaviate.gql.get.GetBuilder.with_limit` method.
+    
+| For example, to list the
+    first ten results, set ``limit: 10``. Then, to "display the second page of 10", set ``offset: 10, limit: 10`` and so on. E.g. 
+    to show the 9th page of 10 results, set ``offset: 80, limit: 10`` to effectively display results 81-90.
+
 Version 3.2.5
 -------------
 This patch fixes the ``'Batch' object is not callable`` error.

--- a/test/gql/test_get.py
+++ b/test/gql/test_get.py
@@ -51,6 +51,25 @@ class TestGetBuilder(unittest.TestCase):
             GetBuilder("A", ["str"], None).with_limit(-1)
         check_error_message(self, error, limit_error_msg)
 
+    def test_build_with_offset(self):
+        """
+        Test the `with_limit` method.
+        """
+
+        # valid calls
+        query = GetBuilder("Person", "name", None).with_offset(20).build()
+        self.assertEqual('{Get{Person(offset: 20 ){name}}}', query)
+
+        # invalid calls
+        limit_error_msg = 'offset cannot be non-positive (offset >=1).'
+        with self.assertRaises(ValueError) as error:
+            GetBuilder("A", ["str"], None).with_offset(0)
+        check_error_message(self, error, limit_error_msg)
+
+        with self.assertRaises(ValueError) as error:
+            GetBuilder("A", ["str"], None).with_offset(-1)
+        check_error_message(self, error, limit_error_msg)
+
     def test_build_with_where(self):
         """
         Test the ` with_where` method.
@@ -532,8 +551,9 @@ class TestGetBuilder(unittest.TestCase):
             .with_near_text(near_text)\
             .with_where(filter)\
             .with_limit(2)\
+            .with_offset(10)\
             .build()
-        self.assertEqual('{Get{Person(where: {operator: Or operands: [{path: ["name"] operator: Equal valueString: "Alan Turing"}, {path: ["name"] operator: Equal valueString: "John von Neumann"}]} limit: 2 nearText: {concepts: ["computer"] certainty: 0.3 moveTo: {concepts: ["science"] force: 0.1} moveAwayFrom: {concepts: ["airplane"] force: 0.2}} ){name uuid}}}', query)
+        self.assertEqual('{Get{Person(where: {operator: Or operands: [{path: ["name"] operator: Equal valueString: "Alan Turing"}, {path: ["name"] operator: Equal valueString: "John von Neumann"}]} limit: 2 offset: 10 nearText: {concepts: ["computer"] certainty: 0.3 moveTo: {concepts: ["science"] force: 0.1} moveAwayFrom: {concepts: ["airplane"] force: 0.2}} ){name uuid}}}', query)
 
     def test_uncapitalized_class_name(self):
         """

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -8,4 +8,4 @@ class TestVersion(unittest.TestCase):
         Test the `__version__` global variable.
         """
 
-        self.assertEqual(weaviate.__version__, "3.2.5", "Check if the version is set correctly!")
+        self.assertEqual(weaviate.__version__, "3.3.0", "Check if the version is set correctly!")

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -652,8 +652,10 @@ class Batch:
         result_objects = self.create_objects()
         result_references = self.create_references()
         if self._callback is not None:
-            self._callback(result_objects)
-            self._callback(result_references)
+            if result_objects:
+                self._callback(result_objects)
+            if result_references:
+                self._callback(result_references)
 
     def num_objects(self) -> int:
         """

--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -67,6 +67,7 @@ class GetBuilder(GraphQL):
         # thus '__one_level', only one level of complexity
         self._where: Optional[Where] = None  # To store the where filter if it is added
         self._limit: Optional[str] = None  # To store the limit filter if it is added
+        self._offset: Optional[str] = None  # To store the offset filter if it is added
         self._near_ask: Optional[Filter] = None # To store the `near`/`ask` clause if it is added
         self._contains_filter = False  # true if any filter is added
 
@@ -435,7 +436,7 @@ class GetBuilder(GraphQL):
 
         Parameters
         ----------
-        limit : dict
+        limit : int
             The max number of objects returned.
 
         Returns
@@ -453,6 +454,34 @@ class GetBuilder(GraphQL):
             raise ValueError('limit cannot be non-positive (limit >=1).')
 
         self._limit = f'limit: {limit} '
+        self._contains_filter = True
+        return self
+
+    def with_offset(self, offset: int) -> 'GetBuilder':
+        """
+        The offset of objects returned, i.e. the starting index of the returned objects should be
+        used in conjunction with the `with_limit` method.
+
+        Parameters
+        ----------
+        offset : int
+            The offset used for the returned objects.
+
+        Returns
+        -------
+        weaviate.gql.get.GetBuilder
+            The updated GetBuilder.
+
+        Raises
+        ------
+        ValueError
+            If 'offset' is non-positive.
+        """
+
+        if offset < 1:
+            raise ValueError('offset cannot be non-positive (offset >=1).')
+
+        self._offset = f'offset: {offset} '
         self._contains_filter = True
         return self
 
@@ -751,6 +780,8 @@ class GetBuilder(GraphQL):
                 query += str(self._where)
             if self._limit is not None:
                 query += self._limit
+            if self._offset is not None:
+                query += self._offset
             if self._near_ask is not None:
                 query += str(self._near_ask)
             query += ')'

--- a/weaviate/version.py
+++ b/weaviate/version.py
@@ -2,4 +2,4 @@
 Weaviate-Python-Client version.
 """
 
-__version__ = "3.2.5"
+__version__ = "3.3.0"


### PR DESCRIPTION
This minor version adds a new `.with_offset()` for the `Get` queries. This method should be used with the `.with_limit()`. This new feature (introduced in weaviate version `1.8.0`) allows to use pagination functionality with the `Get` queries. The `offset` represents the start index of the objects to be returned, and the number of objects is specified by the `.with_limit()` method.

For example, to list the first ten results, set `limit: 10`. Then, to "display the second page of 10", set `offset: 10, limit: 10` and so on. E.g. to show the 9th page of 10 results, set `offset: 80, limit: 10` to effectively display results 81-90.