### PR TITLE
Fix update and replace with version >=1.14

### DIFF
--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -111,6 +111,21 @@ def test_create_schema():
     client.schema.delete_class("Barbecue")
 
 
+def test_replace_and_update(client):
+    """Test updating an object with put (replace) and patch (update)."""
+    uuid = "28954264-0449-57a2-ade5-e9e08d11f51a"
+    client.data_object.create({"name": "Someone"}, "Person", uuid)
+    person = client.data_object.get_by_id(uuid, class_name="Person")
+    assert person["properties"]["name"] == "Someone"
+    client.data_object.replace({"name": "SomeoneElse"}, "Person", uuid)
+    person = client.data_object.get_by_id(uuid, class_name="Person")
+    assert person["properties"]["name"] == "SomeoneElse"
+    client.data_object.update({"name": "Anyone"}, "Person", uuid)
+    person = client.data_object.get_by_id(uuid, class_name="Person")
+    assert person["properties"]["name"] == "Anyone"
+    client.data_object.delete(uuid, class_name="Person")
+
+
 def test_crud(client):
     chemists: List[str] = []
     _create_objects_batch(client)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-cov==4.0.0
 pytest-benchmark==3.4.1
 pytest-profiling==1.7.0
 coverage==6.5.0
+wheel


### PR DESCRIPTION
With the current code replace/update fails for weaviate versions v14>= as the body is missing the class parameter. This is required according to https://weaviate.io/developers/weaviate/current/restful-api-references/objects.html#parameters-4 and always including the class works