### PR TITLE
Remove UUID dashes

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -316,28 +316,28 @@ class TestUtil(unittest.TestCase):
 
         # valid calls
         result = get_valid_uuid("weaviate://localhost/28f3f61b-b524-45e0-9bbe-2c1550bf73d2")
-        self.assertEqual(result, "28f3f61b-b524-45e0-9bbe-2c1550bf73d2")
+        self.assertEqual(result, "28f3f61bb52445e09bbe2c1550bf73d2")
 
         result = get_valid_uuid("weaviate://otherhost.com/28f3f61b-b524-45e0-9bbe-2c1550bf73d2")
-        self.assertEqual(result, "28f3f61b-b524-45e0-9bbe-2c1550bf73d2")
+        self.assertEqual(result, "28f3f61bb52445e09bbe2c1550bf73d2")
 
         result = get_valid_uuid("http://localhost:8080/v1/objects/1c9cd584-88fe-5010-83d0-017cb3fcb446")
-        self.assertEqual(result, "1c9cd584-88fe-5010-83d0-017cb3fcb446")
+        self.assertEqual(result, "1c9cd58488fe501083d0017cb3fcb446")
 
         result = get_valid_uuid("http://otherhost_2:8080/v1/objects/1c9cd584-88fe-5010-83d0-017cb3fcb446")
-        self.assertEqual(result, "1c9cd584-88fe-5010-83d0-017cb3fcb446")
+        self.assertEqual(result, "1c9cd58488fe501083d0017cb3fcb446")
 
         result = get_valid_uuid("http://otherhost_2:8080/v1/objects/1c9cd58488fe501083d0017cb3fcb446")
-        self.assertEqual(result, "1c9cd584-88fe-5010-83d0-017cb3fcb446")
+        self.assertEqual(result, "1c9cd58488fe501083d0017cb3fcb446")
 
         result = get_valid_uuid("1c9cd584-88fe-5010-83d0-017cb3fcb446")
-        self.assertEqual(result, "1c9cd584-88fe-5010-83d0-017cb3fcb446")
+        self.assertEqual(result, "1c9cd58488fe501083d0017cb3fcb446")
 
         result = get_valid_uuid("1c9cd58488fe501083d0017cb3fcb446")
-        self.assertEqual(result, "1c9cd584-88fe-5010-83d0-017cb3fcb446")
+        self.assertEqual(result, "1c9cd58488fe501083d0017cb3fcb446")
 
         result = get_valid_uuid(uuid_lib.UUID("1c9cd58488fe501083d0017cb3fcb446"))
-        self.assertEqual(result, "1c9cd584-88fe-5010-83d0-017cb3fcb446")
+        self.assertEqual(result, "1c9cd58488fe501083d0017cb3fcb446")
 
         # invalid formats
         type_error_message = "'uuid' must be of type str or uuid.UUID, but was: "

--- a/weaviate/batch/requests.py
+++ b/weaviate/batch/requests.py
@@ -214,7 +214,7 @@ class ObjectsBatchRequest(BatchRequest):
         if uuid is not None:
             batch_item["id"] = get_valid_uuid(uuid)
         else:
-            batch_item["id"] = get_valid_uuid(uuid4().hex)
+            batch_item["id"] = get_valid_uuid(uuid4())
 
         if vector is not None:
             batch_item["vector"] = get_vector(vector)

--- a/weaviate/batch/requests.py
+++ b/weaviate/batch/requests.py
@@ -214,7 +214,7 @@ class ObjectsBatchRequest(BatchRequest):
         if uuid is not None:
             batch_item["id"] = get_valid_uuid(uuid)
         else:
-            batch_item["id"] = uuid4().hex
+            batch_item["id"] = get_valid_uuid(uuid4().hex)
 
         if vector is not None:
             batch_item["vector"] = get_vector(vector)

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -256,7 +256,7 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
         or
         'weaviate://localhost/28f3f61bb52445e09bbe2c1550bf73d2'
         or
-        'fc7eb129f138457fb7271b29db191a67'
+        'fc7eb129-f138-457f-b727-1b29db191a67' / 'fc7eb129f138457fb7271b29db191a67'
 
     Returns
     -------
@@ -272,7 +272,7 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
     """
 
     if isinstance(uuid, uuid_lib.UUID):
-        return str(uuid).replace('-', '')
+        return uuid.hex
 
     if not isinstance(uuid, str):
         raise TypeError("'uuid' must be of type str or uuid.UUID, but was: " + str(type(uuid)))
@@ -283,10 +283,10 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
     if _is_weaviate_url or _is_object_url:
         _uuid = uuid.split("/")[-1]
     try:
-        _uuid = str(uuid_lib.UUID(_uuid))
+        _uuid = uuid_lib.UUID(_uuid).hex
     except ValueError:
         raise ValueError("Not valid 'uuid' or 'uuid' can not be extracted from value") from None
-    return _uuid.replace('-', '')
+    return _uuid
 
 
 def get_vector(vector: Sequence) -> list:

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -244,7 +244,7 @@ def is_object_url(url: str) -> bool:
 
 def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
     """
-    Validate and extract the UUID.
+    Validate and extract the UUID, excluding any dashes within.
 
     Parameters
     ----------
@@ -252,11 +252,11 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
         The UUID to be validated and extracted.
         Should be in the form of an UUID or in form of an URL (weaviate 'beacon' or 'href').
         E.g.
-        'http://localhost:8080/v1/objects/fc7eb129-f138-457f-b727-1b29db191a67'
+        'http://localhost:8080/v1/objects/fc7eb129f138457fb7271b29db191a67'
         or
-        'weaviate://localhost/28f3f61b-b524-45e0-9bbe-2c1550bf73d2'
+        'weaviate://localhost/28f3f61bb52445e09bbe2c1550bf73d2'
         or
-        'fc7eb129-f138-457f-b727-1b29db191a67'
+        'fc7eb129f138457fb7271b29db191a67'
 
     Returns
     -------
@@ -272,7 +272,7 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
     """
 
     if isinstance(uuid, uuid_lib.UUID):
-        return str(uuid)
+        return str(uuid).replace('-', '')
 
     if not isinstance(uuid, str):
         raise TypeError("'uuid' must be of type str or uuid.UUID, but was: " + str(type(uuid)))
@@ -286,7 +286,7 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
         _uuid = str(uuid_lib.UUID(_uuid))
     except ValueError:
         raise ValueError("Not valid 'uuid' or 'uuid' can not be extracted from value") from None
-    return _uuid
+    return _uuid.replace('-', '')
 
 
 def get_vector(vector: Sequence) -> list:


### PR DESCRIPTION
For fixing #130 - opened a new PR from main repo rather than a fork as I did with (#131). 
Also incorporated @StefanBogdan comments from  prev PR.

- `get_valid_uuid()` in util.py now strips dashes
- Wrapped uuid generated in batches in `get_valid_uuid()` in all cases
- Modified tests to exclude dashes