### PR TITLE
Add flake8 linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+exclude = .git, venv, .venv, .pytest_cache, dist, .idea
+ignore = E266, E501, E731, W503

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,13 @@ jobs:
       - uses: psf/black@stable
         with:
           version: "22.10"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: 'pip' # caching pip dependencies
+      - run: pip install -r requirements.txt
+      - name: "Flake 8"
+        run: flake8 .
   unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
   hooks:
     - id: no-commit-to-branch
     - id: trailing-whitespace
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+    - id: flake8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
 from weaviate import __version__
+
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 

--- a/integration/test_stress.py
+++ b/integration/test_stress.py
@@ -104,7 +104,7 @@ def test_stress(batch_size, dynamic):
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()
     client.schema.create(schema)
-    client.batch.configure(batch_size=batch_size, dynamic=dynamic)
+    client.batch.configure(batch_size=batch_size, dynamic=dynamic, num_workers=4)
     authors = create_authors(random.randint(1000, 5000))
     paragraphs = create_paragraphs(random.randint(1000, 5000), authors)
     articles = create_articles(random.randint(1000, 5000), authors, paragraphs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm>=4.59.0,<5.0.0
 pylint
 coverage
 twine
-Sphinx>=4.5.0,<4.6.0
+Sphinx>=5.3.0
 pytest==7.1.3
 pytest-cov==4.0.0
 pytest-benchmark==3.4.1
@@ -12,3 +12,4 @@ pytest-profiling==1.7.0
 coverage==6.5.0
 wheel
 pre-commit
+flake8

--- a/test/batch/test_requests.py
+++ b/test/batch/test_requests.py
@@ -1,9 +1,9 @@
 """
 Test the 'weaviate.batch.requests' functions/classes.
 """
-import uuid
 import unittest
 from unittest.mock import patch
+
 from test.util import check_error_message
 from weaviate.batch.requests import ReferenceBatchRequest, ObjectsBatchRequest
 

--- a/test/connection/test_connection.py
+++ b/test/connection/test_connection.py
@@ -1,11 +1,12 @@
-from operator import add
 import unittest
 from unittest.mock import patch, Mock
+
 from requests import RequestException
-from weaviate.auth import AuthClientPassword
-from weaviate.exceptions import AuthenticationFailedException
-from weaviate.connect.connection import Connection, _get_proxies, _get_valid_timeout_config
+
 from test.util import check_error_message
+from weaviate.auth import AuthClientPassword
+from weaviate.connect.connection import Connection, _get_proxies, _get_valid_timeout_config
+from weaviate.exceptions import AuthenticationFailedException
 
 
 class TestConnection(unittest.TestCase):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -180,7 +180,7 @@ class TestWeaviateClient(unittest.TestCase):
         client._connection = connection_mock
         with self.assertRaises(UnexpectedStatusCodeException) as error:
             client.get_open_id_configuration()
-        error_message = f"Meta endpoint! Unexpected status code: 204, with response body: None."
+        error_message = "Meta endpoint! Unexpected status code: 204, with response body: None."
         check_error_message(self, error, error_message)
         connection_mock.get.assert_called_with(path="/.well-known/openid-configuration")
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,7 +1,14 @@
 import unittest
 from unittest.mock import Mock
 
-from weaviate.exceptions import *
+from requests import exceptions
+
+from weaviate.exceptions import (
+    UnexpectedStatusCodeException,
+    ObjectAlreadyExistsException,
+    AuthenticationFailedException,
+    SchemaValidationException,
+)
 
 
 class TestExceptions(unittest.TestCase):
@@ -12,8 +19,7 @@ class TestExceptions(unittest.TestCase):
 
         # with .json() exception raised
         response = Mock()
-        response.json = Mock()
-        response.json.side_effect = Exception("Test")
+        response.json = Mock(side_effect=exceptions.JSONDecodeError("test", "", 0))
         response.status_code = 1234
         exception = UnexpectedStatusCodeException(message="Test message", response=response)
         self.assertEqual(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,10 @@
 import unittest
-from copy import deepcopy
 import uuid as uuid_lib
+from copy import deepcopy
 from unittest.mock import patch, Mock
+
+from test.util import check_error_message
+from weaviate import SchemaValidationException
 from weaviate.util import (
     generate_uuid5,
     image_decoder_b64,
@@ -15,9 +18,6 @@ from weaviate.util import (
     _get_dict_from_object,
     _is_sub_schema,
 )
-from weaviate import SchemaValidationException
-from test.util import check_error_message
-
 
 schema_set = {
     "classes": [
@@ -30,7 +30,7 @@ schema_set = {
 
 schema_set_extended_prop = {
     "classes": [
-        {"class": "Ollie", "properties": [{"name": "height", "name": "weight"}]},
+        {"class": "Ollie", "properties": [{"name": "weight"}]},
         {"class": "Shuvit", "properties": [{"name": "direction"}]},
         {"class": "Board", "properties": [{"name": "brand"}, {"name": "art"}, {"name": "size"}]},
         {"class": "Truck", "properties": [{"name": "name"}, {"name": "height"}]},

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -43,11 +43,16 @@ __all__ = [
 ]
 
 import sys
-from .version import __version__
-from .exceptions import *
+
 from .auth import AuthClientCredentials, AuthClientPassword
 from .client import Client
-
+from .exceptions import (
+    UnexpectedStatusCodeException,
+    ObjectAlreadyExistsException,
+    AuthenticationFailedException,
+    SchemaValidationException,
+)
+from .version import __version__  # noqa
 
 if not sys.warnoptions:
     import warnings

--- a/weaviate/classification/config_builder.py
+++ b/weaviate/classification/config_builder.py
@@ -16,7 +16,7 @@ class ConfigBuilder:
     ConfigBuild class that is used to configure a classification process.
     """
 
-    def __init__(self, connection: Connection, classification: "Classification"):
+    def __init__(self, connection: Connection, classification: "Classification"):  # noqa
         """
         Initialize a ConfigBuilder class instance.
 

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -1,8 +1,7 @@
 """
 Weaviate Exceptions.
 """
-# Import requests ConnectionError as weaviate.ConnectionError to overwrite buildins connection error
-from requests import Response
+from requests import Response, exceptions
 
 ERROR_CODE_EXPLANATION = {
     413: """Payload Too Large. Try to decrease the batch size or increase the maximum request size on your weaviate
@@ -56,7 +55,7 @@ class UnexpectedStatusCodeException(WeaviateBaseError):
 
         try:
             body = response.json()
-        except:
+        except exceptions.JSONDecodeError:
             body = None
 
         msg = (

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -651,7 +651,7 @@ def _check_direction_clause(direction: dict) -> dict:
         _check_concept(direction)
     if "objects" in direction:
         _check_objects(direction)
-    if not "force" in direction:
+    if "force" not in direction:
         raise ValueError("'move' clause needs to state a 'force'")
     _check_type(var_name="force", value=direction["force"], dtype=float)
 


### PR DESCRIPTION
Adds flake8 linter

- First commit adds precommit and CI entries ([which fails without the fixes](https://github.com/semi-technologies/weaviate-python-client/actions/runs/3450599851/jobs/5759289934))
- Second commit adds fixes

The base linter is not that helpful, but there are several plugins that I want to add later.

Not that this MR is based on [this PR](https://github.com/semi-technologies/weaviate-python-client/pull/159), which should be merged first 