### PR TITLE
Warning on auth with anon weav + create warning factory

### DIFF
--- a/mock_tests/test_batching_manual.py
+++ b/mock_tests/test_batching_manual.py
@@ -1,0 +1,32 @@
+import uuid
+
+import weaviate
+
+
+def test_manual_batching_warning_object(recwarn, weaviate_mock):
+    weaviate_mock.expect_request("/v1/batch/objects").respond_with_json({})
+
+    client = weaviate.Client(url="http://127.0.0.1:23534")
+
+    client.batch.add_data_object({}, "ExistingClass")
+    client.batch.create_objects()
+
+    assert len(recwarn) == 1
+    w = recwarn.pop()
+    assert issubclass(w.category, DeprecationWarning)
+    assert str(w.message).startswith("Dep002")
+
+
+def test_manual_batching_warning_ref(recwarn, weaviate_mock):
+    weaviate_mock.expect_request("/v1/batch/references").respond_with_json({})
+
+    client = weaviate.Client(url="http://127.0.0.1:23534")
+    client.batch.add_reference(
+        str(uuid.uuid4()), "NonExistingClass", "existsWith", str(uuid.uuid4()), "OtherClass"
+    )
+    client.batch.create_references()
+
+    assert len(recwarn) == 1
+    w = recwarn.pop()
+    assert issubclass(w.category, DeprecationWarning)
+    assert str(w.message).startswith("Dep002")

--- a/mock_tests/test_connection.py
+++ b/mock_tests/test_connection.py
@@ -2,6 +2,7 @@ import json
 from typing import Dict
 
 import pytest
+from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 import weaviate
@@ -18,8 +19,6 @@ import weaviate
 def test_additional_headers(weaviate_mock, header: Dict[str, str]):
     """Test that client sends given headers."""
 
-    # weaviate_mock.expect_request("/v1/schema", headers={"Authorization":"dfsdf"}).respond_with_json({})
-
     def handler(request: Request):
         assert request.headers["content-type"] == "application/json"
         for key, val in header.items():
@@ -30,3 +29,18 @@ def test_additional_headers(weaviate_mock, header: Dict[str, str]):
 
     client = weaviate.Client(url="http://127.0.0.1:23534", additional_headers=header)
     client.schema.delete_all()  # some call that includes headers
+
+
+@pytest.mark.parametrize("version,warning", [("1.13", True), ("1.14", False)])
+def test_warning_old_weaviate(recwarn, httpserver: HTTPServer, version: str, warning: bool):
+    """Test that we warn if a new client version is using an old weaviate server."""
+    httpserver.expect_request("/v1/meta").respond_with_json({"version": version})
+    weaviate.Client(url="http://127.0.0.1:23534")
+
+    if warning:
+        assert len(recwarn) == 1
+        w = recwarn.pop()
+        assert issubclass(w.category, DeprecationWarning)
+        assert str(w.message).startswith("Dep001")
+    else:
+        assert len(recwarn) == 0

--- a/test/connection/test_connection.py
+++ b/test/connection/test_connection.py
@@ -2,14 +2,14 @@ import unittest
 from unittest.mock import patch, Mock
 
 from test.util import check_error_message
-from weaviate.connect.connection import Connection, _get_proxies, _get_valid_timeout_config
+from weaviate.connect.connection import BaseConnection, _get_proxies, _get_valid_timeout_config
 from weaviate.exceptions import AuthenticationFailedException
 
 
 class TestConnection(unittest.TestCase):
     def check_connection_attributes(
         self,
-        connection: Connection,
+        connection: BaseConnection,
         url="test_url",
         timeout_config=(2, 20),
         auth_expires=0,
@@ -44,7 +44,7 @@ class TestConnection(unittest.TestCase):
         if headers != "skip":
             self.assertEqual(connection._headers, headers)
 
-    @patch("weaviate.connect.connection.Connection._refresh_authentication")
+    @patch("weaviate.connect.connection.BaseConnection._refresh_authentication")
     @patch("weaviate.connect.connection.requests")
     def test__init__(self, mock_requests, mock_refresh_authentication):
         """
@@ -63,7 +63,7 @@ class TestConnection(unittest.TestCase):
 
         # additional_headers error check
         with self.assertRaises(TypeError) as error:
-            Connection(
+            BaseConnection(
                 url="test_url",
                 auth_client_secret=None,
                 timeout_config=(3, 23),
@@ -78,7 +78,7 @@ class TestConnection(unittest.TestCase):
         mock_session.get.side_effect = None
         mock_response = Mock(status_code=400)
         mock_session.get.return_value = mock_response
-        connection = Connection(
+        connection = BaseConnection(
             url="test_url",
             auth_client_secret=None,
             timeout_config=(3, 23),
@@ -100,7 +100,7 @@ class TestConnection(unittest.TestCase):
         mock_response = Mock(status_code=200)
         mock_session.get.return_value = mock_response
         with self.assertRaises(AuthenticationFailedException) as error:
-            Connection(
+            BaseConnection(
                 url="test_url",
                 auth_client_secret=None,
                 timeout_config=(2, 20),
@@ -117,8 +117,8 @@ class TestConnection(unittest.TestCase):
         )
 
         # 200 status_code return and token provided
-        with patch("weaviate.connect.connection.Connection._log_in") as mock_login:
-            connection = Connection(
+        with patch("weaviate.connect.connection.BaseConnection._log_in") as mock_login:
+            connection = BaseConnection(
                 url="test_url",
                 auth_client_secret=None,
                 timeout_config=(2, 20),
@@ -140,7 +140,7 @@ class TestConnection(unittest.TestCase):
         """
 
         mock_session = mock_requests.Session.return_value = Mock()
-        connection = Connection(
+        connection = BaseConnection(
             url="http://weaviate:1234",
             auth_client_secret=None,
             timeout_config=(2, 20),
@@ -217,7 +217,7 @@ class TestConnection(unittest.TestCase):
         # add Proxies
 
         mock_session = mock_requests.Session.return_value = Mock()
-        connection = Connection(
+        connection = BaseConnection(
             url="http://weaviate:1234",
             auth_client_secret=None,
             timeout_config=(2, 20),
@@ -291,13 +291,13 @@ class TestConnection(unittest.TestCase):
             proxies={"test": True},
         )
 
-    @patch("weaviate.connect.connection.Connection._log_in")
+    @patch("weaviate.connect.connection.BaseConnection._log_in")
     def test_timeout_config(self, mock_log_in):
         """
         Test the setter and getter of `timeout_config`.
         """
 
-        connection = Connection(
+        connection = BaseConnection(
             url="http://test_url",
             auth_client_secret=None,
             timeout_config=(2, 20),

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -12,10 +12,9 @@ from typing import Tuple, Callable, Optional, Sequence
 from requests import ReadTimeout, Response
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from weaviate.connect import Connection
 from .requests import BatchRequest, ObjectsBatchRequest, ReferenceBatchRequest
-from ..connect import Connection
 from ..error_msgs import (
-    BATCH_MANUAL_USE_W,
     BATCH_REF_DEPRECATION_NEW_V14_CLS_NS_W,
     BATCH_REF_DEPRECATION_OLD_V14_CLS_NS_W,
     BATCH_EXECUTOR_SHUTDOWN_W,
@@ -25,6 +24,7 @@ from ..util import (
     _capitalize_first_letter,
     check_batch_result,
 )
+from ..warnings import _Warnings
 
 
 class BatchExecutor(ThreadPoolExecutor):
@@ -756,11 +756,7 @@ class Batch:
         """
 
         if len(self._objects_batch) != 0:
-            warnings.warn(
-                message=BATCH_MANUAL_USE_W,
-                category=RuntimeWarning,
-                stacklevel=1,
-            )
+            _Warnings.manual_batching()
 
             response = self._create_data(
                 data_type="objects",
@@ -855,11 +851,7 @@ class Batch:
         """
 
         if len(self._reference_batch) != 0:
-            warnings.warn(
-                message=BATCH_MANUAL_USE_W,
-                category=RuntimeWarning,
-                stacklevel=1,
-            )
+            _Warnings.manual_batching()
 
             response = self._create_data(
                 data_type="references",

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -1,7 +1,6 @@
 """
 Client class definition.
 """
-import warnings
 from numbers import Real
 from typing import Optional, Tuple, Union
 
@@ -12,10 +11,9 @@ from .backup import Backup
 from .batch import Batch
 from .classification import Classification
 from .cluster import Cluster
-from .connect import Connection
+from .connect.connection import Connection
 from .contextionary import Contextionary
 from .data import DataObject
-from .error_msgs import CLIENT_V14_W
 from .exceptions import UnexpectedStatusCodeException
 from .gql import Query
 from .schema import Schema
@@ -135,15 +133,6 @@ class Client:
         self.backup = Backup(self._connection)
         self.cluster = Cluster(self._connection)
 
-        self._set_server_version()
-
-        if self._connection.server_version < "1.14":
-            warnings.warn(
-                message=CLIENT_V14_W,
-                category=DeprecationWarning,
-                stacklevel=1,
-            )
-
     def is_ready(self) -> bool:
         """
         Ping Weaviate's ready state
@@ -194,10 +183,8 @@ class Client:
             If weaviate reports a none OK status.
         """
 
-        response = self._connection.get(path="/meta")
-        if response.status_code == 200:
-            return response.json()
-        raise UnexpectedStatusCodeException("Meta endpoint", response)
+        response = self._connection._meta
+        return response.json()
 
     def get_open_id_configuration(self) -> Optional[dict]:
         """
@@ -250,10 +237,3 @@ class Client:
         """
 
         self._connection.timeout_config = timeout_config
-
-    def _set_server_version(self):
-        """
-        Set Weaviate Server version.
-        """
-
-        self._connection.server_version = self.get_meta()["version"]

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -183,7 +183,7 @@ class Client:
             If weaviate reports a none OK status.
         """
 
-        response = self._connection._meta
+        response = self._connection.get_meta()
         return response.json()
 
     def get_open_id_configuration(self) -> Optional[dict]:

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -16,15 +16,15 @@ from weaviate.auth import (
 from weaviate.exceptions import MissingScopeException, AuthenticationFailedException
 
 if TYPE_CHECKING:
-    from . import Connection
+    from . import BaseConnection
 
 
 class _Auth:
     def __init__(
-        self, response: Dict[str, str], auth_config: AuthCredentials, connection: Connection
+        self, response: Dict[str, str], auth_config: AuthCredentials, connection: BaseConnection
     ) -> None:
         self._auth_config: AuthCredentials = auth_config
-        self._connection: Connection = connection
+        self._connection: BaseConnection = connection
 
         self._open_id_config_url: str = response["href"]
         self._client_id: str = response["clientId"]

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -14,6 +14,7 @@ import requests
 from weaviate.auth import AuthCredentials
 from weaviate.connect.authentication import _Auth
 from weaviate.exceptions import AuthenticationFailedException
+from weaviate.warnings import _Warnings
 
 
 class Connection:
@@ -120,6 +121,8 @@ class Connection:
                     f""""No login credentials provided. The weaviate instance at {self.url} requires login credential,
                     use argument 'auth_client_secret'."""
                 )
+        elif response.status_code == 404 and self._auth_client_secret is not None:
+            _Warnings.auth_with_anon_weaviate()
 
     def __del__(self):
         """

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -67,7 +67,6 @@ class BaseConnection:
         """
 
         self._api_version_path = "/v1"
-        self._server_version = None
         self._session = requests.Session()
         self.url = url  # e.g. http://localhost:80
         self.timeout_config = timeout_config  # this uses the setter
@@ -441,22 +440,16 @@ class Connection(BaseConnection):
         super().__init__(
             url, auth_client_secret, timeout_config, proxies, trust_env, additional_headers
         )
-        self._meta = self._get_meta()
-        self._server_version = self._meta["version"]
-        if self._server_version < "1.14":
-            _Warnings.weaviate_server_older_than_1_14(self._server_version)
+        version = self.get_meta()["version"]
+        if version < "1.14":
+            _Warnings.weaviate_server_older_than_1_14(version)
 
     @property
     def server_version(self) -> str:
         """Version of the weaviate instance."""
-        return self._server_version
+        return self.get_meta()["version"]
 
-    @property
-    def meta(self) -> Dict[str, str]:
-        """Version of the weaviate instance."""
-        return self._meta
-
-    def _get_meta(self) -> Dict[str, str]:
+    def get_meta(self) -> Dict[str, str]:
         """Returns the meta endpoint."""
         response = self.get(path="/meta")
         if response.status_code == 200:

--- a/weaviate/error_msgs.py
+++ b/weaviate/error_msgs.py
@@ -1,15 +1,6 @@
 """
 Error/Warning messages that are reused throughout the code.
 """
-from .version import __version__
-
-
-CLIENT_V14_W = (
-    f"You are using the Weaviate Python Client version {__version__} which has "
-    "the new changes/features of the Weaviate Server 1.14.x. If you want to make use "
-    "of the new changes/features of the Weaviate Server 1.14.x using this Python "
-    "Client version, upgrade the Weaviate Server version.",
-)
 
 
 FILTER_BEACON_V14_CLS_NS_W = (

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -1,5 +1,7 @@
 import warnings
 
+import weaviate.version as version
+
 
 class _Warnings:
     @staticmethod
@@ -8,5 +10,16 @@ class _Warnings:
             message="""Auth001: The client was configured to use authentication, but weaviate is configured without
                     authentication. Are you sure this is correct?""",
             category=UserWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
+    def weaviate_server_older_than_1_14(server_version: str):
+        warnings.warn(
+            message=f"""Dep001: You are using the Weaviate Python Client version {version.__version__} which supports
+            changes and features of Weaviate >=1.14.x, but you are connected to Weaviate {server_version}.
+            If you want to make use of these new changes/features using this Python Client version, upgrade your
+            Weaviate instance.""",
+            category=DeprecationWarning,
             stacklevel=1,
         )

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -1,0 +1,12 @@
+import warnings
+
+
+class _Warnings:
+    @staticmethod
+    def auth_with_anon_weaviate():
+        warnings.warn(
+            message="""Auth001: The client was configured to use authentication, but weaviate is configured without
+                    authentication. Are you sure this is correct?""",
+            category=UserWarning,
+            stacklevel=1,
+        )

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -23,3 +23,14 @@ class _Warnings:
             category=DeprecationWarning,
             stacklevel=1,
         )
+
+    @staticmethod
+    def manual_batching():
+        warnings.warn(
+            message="""Dep002: You are batching manually. This means you are NOT using the client's built-in
+            multi-threading. Setting `batch_size` in `client.batch.configure()`  to an int value will enabled automatic
+            batching. See:
+            https://weaviate.io/developers/weaviate/current/restful-api-references/batch.html#example-request-1""",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )

--- a/weaviate/wcs/crud_wcs.py
+++ b/weaviate/wcs/crud_wcs.py
@@ -9,14 +9,14 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from tqdm.auto import tqdm
 
 from weaviate.auth import AuthClientPassword
-from weaviate.connect import Connection
+from weaviate.connect.connection import BaseConnection
 from weaviate.exceptions import (
     UnexpectedStatusCodeException,
     AuthenticationFailedException,
 )
 
 
-class WCS(Connection):
+class WCS(BaseConnection):
     """
     WCS class used to create/delete WCS cluster instances.
 


### PR DESCRIPTION
This PR adds:

- A warning when the client is configured with authentication, but weaviate is not
- Refactors the handling of the meta endpoint/server version
- Moves two other warning into the new _Warnings class (more to follow at some point in the future) + add tests with mock server