### PR TITLE
Use oauth2 clients for all auth methods

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
         cache: 'pip' # caching pip dependencies
     - run: pip install -r requirements.txt
     - name: Run unittests
-      run: pytest --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage.xml ${{ matrix.folder }}
+      run: pytest --cov -v --cov-report=term-missing --cov=weaviate --cov-report xml:coverage.xml ${{ matrix.folder }}
     - name: Upload to codecov
       if: matrix.version == '3.10' && (github.ref_name != 'master')
       uses: codecov/codecov-action@v3
@@ -73,9 +73,10 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           OKTA_CLIENT_SECRET: ${{ secrets.OKTA_CLIENT_SECRET }}
           WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
+          OKTA_DUMMY_CI_PW: ${{ secrets.OKTA_DUMMY_CI_PW }}
         run: |
           /bin/bash ci/start_weaviate.sh
-          pytest --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage.xml integration
+          pytest -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage.xml integration
       - name: Upload to codecov
         if: matrix.version == '3.10' && (github.ref_name != 'master')
         uses: codecov/codecov-action@v3

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -1,7 +1,7 @@
 ---
 version: '3.4'
 services:
-  weaviate-auth-okta:
+  weaviate-auth-okta-cc:
     command:
       - --host
       - 0.0.0.0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -1,28 +1,29 @@
 ---
 version: '3.4'
 services:
-  weaviate-auth-wcs:
+  weaviate-auth-okta-users:
     command:
       - --host
       - 0.0.0.0
       - --port
-      - '8084'
+      - '8083'
       - --scheme
       - http
       - --write-timeout=600s
     image: semitechnologies/weaviate:1.15.4-b7811d4
     ports:
-      - 8084:8084
+      - 8083:8083
     restart: on-failure:0
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
       AUTHENTICATION_OIDC_ENABLED: 'true'
-      AUTHENTICATION_OIDC_CLIENT_ID: 'wcs'
-      AUTHENTICATION_OIDC_ISSUER: 'https://auth.wcs.api.semi.technology/auth/realms/SeMI'
-      AUTHENTICATION_OIDC_USERNAME_CLAIM: 'email'
+      AUTHENTICATION_OIDC_CLIENT_ID: '0oa7iz2g41rNxv95B5d7'
+      AUTHENTICATION_OIDC_ISSUER: 'https://dev-32300990.okta.com/oauth2/aus7iz3tna3kckRWS5d7'
+      AUTHENTICATION_OIDC_USERNAME_CLAIM: 'sub'
       AUTHENTICATION_OIDC_GROUPS_CLAIM: 'groups'
       AUTHORIZATION_ADMINLIST_ENABLED: 'true'
-      AUTHORIZATION_ADMINLIST_USERS: 'ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net'
+      AUTHORIZATION_ADMINLIST_USERS: 'test@test.de'
       AUTHENTICATION_OIDC_SCOPES: 'openid,email'
 ...
+

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -6,13 +6,13 @@ services:
       - --host
       - 0.0.0.0
       - --port
-      - '8084'
+      - '8085'
       - --scheme
       - http
       - --write-timeout=600s
     image: semitechnologies/weaviate:1.15.4-b7811d4
     ports:
-      - 8084:8084
+      - 8085:8085
     restart: on-failure:0
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'

--- a/ci/start_weaviate.sh
+++ b/ci/start_weaviate.sh
@@ -3,12 +3,13 @@
 echo "Run Docker compose"
 nohup docker-compose -f ci/docker-compose.yml up -d
 nohup docker-compose -f ci/docker-compose-azure.yml up -d
-nohup docker-compose -f ci/docker-compose-okta.yml up -d
+nohup docker-compose -f ci/docker-compose-okta-cc.yml up -d
+nohup docker-compose -f ci/docker-compose-okta-users.yml up -d
 nohup docker-compose -f ci/docker-compose-wcs.yml up -d
 
 echo "Wait until weaviate is up"
 
-for port in 8080 8081 8082 8083
+for port in 8080 8081 8082 8083 8084
 do
   # pulling all images usually takes < 3 min
   # starting weaviate usually takes < 2 min

--- a/ci/start_weaviate.sh
+++ b/ci/start_weaviate.sh
@@ -9,7 +9,7 @@ nohup docker-compose -f ci/docker-compose-wcs.yml up -d
 
 echo "Wait until weaviate is up"
 
-for port in 8080 8081 8082 8083 8084
+for port in 8080 8081 8082 8083 8085
 do
   # pulling all images usually takes < 3 min
   # starting weaviate usually takes < 2 min
@@ -20,9 +20,9 @@ do
     i=$(($i+5))
     echo "Sleep $i"
     sleep 5
-    if [ $i -gt 300 ]; then
+    if [ $i -gt 150 ]; then
       echo "Weaviate did not start in time"
-      cat nohup.out
+      bash ./ci/stop_weaviate.sh
       exit 1
     fi
     STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" localhost:"$port"/v1/.well-known/ready)

--- a/ci/stop_weaviate.sh
+++ b/ci/stop_weaviate.sh
@@ -2,5 +2,6 @@
 
 docker-compose -f ci/docker-compose.yml down --remove-orphans
 docker-compose -f ci/docker-compose-azure.yml down --remove-orphans
-docker-compose -f ci/docker-compose-okta.yml down --remove-orphans
+docker-compose -f ci/docker-compose-okta-cc.yml down --remove-orphans
+docker-compose -f ci/docker-compose-okta-users.yml down --remove-orphans
 docker-compose -f ci/docker-compose-wcs.yml down --remove-orphans

--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Optional, Dict
 
 import pytest
@@ -16,7 +17,7 @@ ANON_PORT = "8080"
 AZURE_PORT = "8081"
 OKTA_PORT_CC = "8082"
 OKTA_PORT_USERS = "8083"
-WCS_PORT = "8084"
+WCS_PORT = "8085"
 
 
 def is_auth_enabled(url: str):
@@ -95,6 +96,9 @@ def test_authentication_user_pw(
     recwarn, name: str, user: str, env_variable_name: str, port: str, scope: str, warning: bool
 ):
     """Test authentication using Resource Owner Password Credentials Grant (User + PW)."""
+    # testing for warnings can be flaky without this as there are open SSL conections
+    warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+
     url = "http://127.0.0.1:" + port
     assert is_auth_enabled(url)
 
@@ -182,6 +186,9 @@ def test_authentication_with_bearer_token(name: str, user: str, env_variable_nam
 
 def test_client_with_authentication_with_anon_weaviate(recwarn):
     """Test that we warn users when their client has auth enabled, but weaviate has only anon access."""
+    # testing for warnings can be flaky without this as there are open SSL conections
+    warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+
     url = "http://127.0.0.1:" + ANON_PORT
     assert not is_auth_enabled(url)
 
@@ -201,6 +208,10 @@ def test_client_with_authentication_with_anon_weaviate(recwarn):
 
 def test_bearer_token_without_refresh(recwarn):
     """Test that the client warns users when only supplying an access token without refresh."""
+
+    # testing for warnings can be flaky without this as there are open SSL conections
+    warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+
     url = "http://127.0.0.1:" + WCS_PORT
     assert is_auth_enabled(url)
     pw = os.environ.get("WCS_DUMMY_CI_PW")
@@ -214,7 +225,6 @@ def test_bearer_token_without_refresh(recwarn):
             access_token=token["access_token"],
         ),
     )
-
     client.schema.delete_all()  # no exception, client works
 
     assert len(recwarn) == 1

--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -176,9 +176,8 @@ def test_authentication_with_bearer_token(name: str, user: str, env_variable_nam
         url,
         auth_client_secret=AuthBearerToken(
             access_token=token["access_token"],
-            expires_in=token["expires_in"],
+            expires_in=int(token["expires_in"]),
             refresh_token=token["refresh_token"],
-            refresh_expires_in=token.get("refresh_expires_in", None),
         ),
     )
     client.schema.delete_all()  # no exception

--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -171,7 +171,7 @@ def test_authentication_with_bearer_token(name: str, user: str, env_variable_nam
     client = weaviate.Client(
         url,
         auth_client_secret=AuthBearerToken(
-            bearer_token=token["access_token"],
+            access_token=token["access_token"],
             expires_in=token["expires_in"],
             refresh_token=token["refresh_token"],
             refresh_expires_in=token.get("refresh_expires_in", None),
@@ -211,7 +211,7 @@ def test_bearer_token_without_refresh(recwarn):
     client = weaviate.Client(
         url,
         auth_client_secret=AuthBearerToken(
-            bearer_token=token["access_token"],
+            access_token=token["access_token"],
         ),
     )
 

--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -1,16 +1,22 @@
 import os
-from typing import Optional
+from typing import Optional, Dict
 
 import pytest
 import requests
 
 import weaviate
-from weaviate import AuthenticationFailedException, AuthClientCredentials, AuthClientPassword
+from weaviate import (
+    AuthenticationFailedException,
+    AuthClientCredentials,
+    AuthClientPassword,
+    AuthBearerToken,
+)
 
 ANON_PORT = "8080"
 AZURE_PORT = "8081"
-OKTA_PORT = "8082"
-WCS_PORT = "8083"
+OKTA_PORT_CC = "8082"
+OKTA_PORT_USERS = "8083"
+WCS_PORT = "8084"
 
 
 def is_auth_enabled(url: str):
@@ -36,7 +42,7 @@ def test_no_auth_provided():
             AZURE_PORT,
             "4706508f-30c2-469b-8b12-ad272b3de864/.default",
         ),
-        ("okta", "OKTA_CLIENT_SECRET", OKTA_PORT, "some_scope"),
+        ("okta", "OKTA_CLIENT_SECRET", OKTA_PORT_CC, "some_scope"),
     ],
 )
 def test_authentication_client_credentials(
@@ -55,19 +61,120 @@ def test_authentication_client_credentials(
     client.schema.delete_all()  # no exception
 
 
-def test_authentication_user_pw():
+@pytest.mark.parametrize(
+    "name,user,env_variable_name,port,scope,warning",
+    [
+        (
+            "WCS",
+            "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net",
+            "WCS_DUMMY_CI_PW",
+            WCS_PORT,
+            None,
+            False,
+        ),
+        (
+            "okta",
+            "test@test.de",
+            "OKTA_DUMMY_CI_PW",
+            OKTA_PORT_USERS,
+            "some_scope offline_access",
+            False,
+        ),
+        ("okta - default scope", "test@test.de", "OKTA_DUMMY_CI_PW", OKTA_PORT_USERS, None, False),
+        (
+            "okta - no refresh",
+            "test@test.de",
+            "OKTA_DUMMY_CI_PW",
+            OKTA_PORT_USERS,
+            "some_scope",
+            True,
+        ),
+    ],
+)
+def test_authentication_user_pw(
+    recwarn, name: str, user: str, env_variable_name: str, port: str, scope: str, warning: bool
+):
     """Test authentication using Resource Owner Password Credentials Grant (User + PW)."""
-    url = "http://127.0.0.1:" + WCS_PORT
+    url = "http://127.0.0.1:" + port
     assert is_auth_enabled(url)
 
-    wcs_pw = os.environ.get("WCS_DUMMY_CI_PW")
-    if wcs_pw is None:
-        pytest.skip("No login data for WCS found.")
+    pw = os.environ.get(env_variable_name)
+    if pw is None:
+        pytest.skip(f"No login data for {name} found.")
+
+    if scope is not None:
+        auth = AuthClientPassword(username=user, password=pw, scope=scope)
+    else:
+        auth = AuthClientPassword(username=user, password=pw)
+
+    client = weaviate.Client(url, auth_client_secret=auth)
+    client.schema.delete_all()  # no exception
+    if warning:
+        assert len(recwarn) == 1
+        w = recwarn.pop()
+        assert issubclass(w.category, UserWarning)
+        assert str(w.message).startswith("Auth002")
+    else:
+        assert len(recwarn) == 0
+
+
+def _get_access_token(url: str, user: str, pw: str) -> Dict[str, str]:
+    # get an access token with WCS user and pw.
+    weaviate_open_id_config = requests.get(url + "/v1/.well-known/openid-configuration")
+    response_json = weaviate_open_id_config.json()
+    client_id = response_json["clientId"]
+    href = response_json["href"]
+
+    # Get the token issuer's OIDC configuration
+    response_auth = requests.get(href)
+
+    # Construct the POST request to send to 'token_endpoint'
+    auth_body = {
+        "grant_type": "password",
+        "client_id": client_id,
+        "username": user,
+        "password": pw,
+        "scope": "openid offline_access",
+    }
+    response_post = requests.post(response_auth.json()["token_endpoint"], auth_body)
+    return response_post.json()
+
+
+@pytest.mark.parametrize(
+    "name,user,env_variable_name,port",
+    [
+        (
+            "WCS",
+            "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net",
+            "WCS_DUMMY_CI_PW",
+            WCS_PORT,
+        ),
+        (
+            "okta",
+            "test@test.de",
+            "OKTA_DUMMY_CI_PW",
+            OKTA_PORT_USERS,
+        ),
+    ],
+)
+def test_authentication_with_bearer_token(name: str, user: str, env_variable_name: str, port: str):
+    """Test authentication using existing bearer token."""
+    url = "http://127.0.0.1:" + port
+    assert is_auth_enabled(url)
+    pw = os.environ.get(env_variable_name)
+    if pw is None:
+        pytest.skip(f"No login data for {name} found.")
+
+    # use token to authenticate
+    token = _get_access_token(url, user, pw)
 
     client = weaviate.Client(
         url,
-        auth_client_secret=AuthClientPassword(
-            username="ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net", password=wcs_pw
+        auth_client_secret=AuthBearerToken(
+            bearer_token=token["access_token"],
+            expires_in=token["expires_in"],
+            refresh_token=token["refresh_token"],
+            refresh_expires_in=token.get("refresh_expires_in", None),
         ),
     )
     client.schema.delete_all()  # no exception
@@ -90,3 +197,27 @@ def test_client_with_authentication_with_anon_weaviate(recwarn):
     assert str(w.message).startswith("Auth001")
 
     client.schema.delete_all()  # no exception, client works
+
+
+def test_bearer_token_without_refresh(recwarn):
+    """Test that the client warns users when only supplying an access token without refresh."""
+    url = "http://127.0.0.1:" + WCS_PORT
+    assert is_auth_enabled(url)
+    pw = os.environ.get("WCS_DUMMY_CI_PW")
+    if pw is None:
+        pytest.skip("No login data for WCS found.")
+
+    token = _get_access_token(url, "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net", pw)
+    client = weaviate.Client(
+        url,
+        auth_client_secret=AuthBearerToken(
+            bearer_token=token["access_token"],
+        ),
+    )
+
+    client.schema.delete_all()  # no exception, client works
+
+    assert len(recwarn) == 1
+    w = recwarn.pop()
+    assert issubclass(w.category, UserWarning)
+    assert str(w.message).startswith("Auth002")

--- a/mock_tests/conftest.py
+++ b/mock_tests/conftest.py
@@ -3,7 +3,7 @@ from pytest_httpserver import HTTPServer
 
 
 MOCK_IP = "127.0.0.1"
-MOCK_PORT = 23535
+MOCK_PORT = 23536
 CLIENT_ID = "DoesNotMatter"
 MOCK_SERVER_URL = "http://" + MOCK_IP + ":" + str(MOCK_PORT)
 

--- a/mock_tests/conftest.py
+++ b/mock_tests/conftest.py
@@ -3,7 +3,7 @@ from pytest_httpserver import HTTPServer
 
 
 MOCK_IP = "127.0.0.1"
-MOCK_PORT = 23534
+MOCK_PORT = 23535
 CLIENT_ID = "DoesNotMatter"
 MOCK_SERVER_URL = "http://" + MOCK_IP + ":" + str(MOCK_PORT)
 

--- a/mock_tests/test_auth.py
+++ b/mock_tests/test_auth.py
@@ -2,6 +2,7 @@ import pytest
 
 import weaviate
 from mock_tests.conftest import MOCK_SERVER_URL, CLIENT_ID
+from weaviate.exceptions import MissingScopeException
 
 ACCESS_TOKEN = "HELLO!IamAnAccessToken"
 CLIENT_SECRET = "SomeSecret.DontTell"
@@ -75,3 +76,13 @@ def test_auth_header_priority(weaviate_auth_mock, header_name: str):
         additional_headers={header_name: "Bearer " + bearer_token},
     )
     client.schema.delete_all()  # some call that includes authorization
+
+
+def test_missing_scope(weaviate_auth_mock):
+    with pytest.raises(MissingScopeException):
+        weaviate.Client(
+            url=MOCK_SERVER_URL,
+            auth_client_secret=weaviate.AuthClientCredentials(
+                client_secret=CLIENT_SECRET, scope=None
+            ),
+        )

--- a/mock_tests/test_auth.py
+++ b/mock_tests/test_auth.py
@@ -16,7 +16,8 @@ def test_user_password(weaviate_auth_mock):
 
     # note: order matters. If this handler is not called, check of the order of arguments changed
     weaviate_auth_mock.expect_request(
-        "/auth", data=f"grant_type=password&username={user}&password={pw}&client_id={CLIENT_ID}"
+        "/auth",
+        data=f"grant_type=password&username={user}&password={pw}&scope=offline_access&client_id={CLIENT_ID}",
     ).respond_with_json({"access_token": ACCESS_TOKEN, "expires_in": 500})
     weaviate_auth_mock.expect_request(
         "/v1/schema", headers={"Authorization": "Bearer " + ACCESS_TOKEN}

--- a/mock_tests/test_batching_manual.py
+++ b/mock_tests/test_batching_manual.py
@@ -1,12 +1,13 @@
 import uuid
 
 import weaviate
+from mock_tests.conftest import MOCK_SERVER_URL
 
 
 def test_manual_batching_warning_object(recwarn, weaviate_mock):
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_json({})
 
-    client = weaviate.Client(url="http://127.0.0.1:23534")
+    client = weaviate.Client(url=MOCK_SERVER_URL)
 
     client.batch.add_data_object({}, "ExistingClass")
     client.batch.create_objects()
@@ -20,7 +21,7 @@ def test_manual_batching_warning_object(recwarn, weaviate_mock):
 def test_manual_batching_warning_ref(recwarn, weaviate_mock):
     weaviate_mock.expect_request("/v1/batch/references").respond_with_json({})
 
-    client = weaviate.Client(url="http://127.0.0.1:23534")
+    client = weaviate.Client(url=MOCK_SERVER_URL)
     client.batch.add_reference(
         str(uuid.uuid4()), "NonExistingClass", "existsWith", str(uuid.uuid4()), "OtherClass"
     )

--- a/mock_tests/test_connection.py
+++ b/mock_tests/test_connection.py
@@ -6,6 +6,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 import weaviate
+from mock_tests.conftest import MOCK_SERVER_URL
 
 
 @pytest.mark.parametrize(
@@ -27,7 +28,7 @@ def test_additional_headers(weaviate_mock, header: Dict[str, str]):
 
     weaviate_mock.expect_request("/v1/schema").respond_with_handler(handler)
 
-    client = weaviate.Client(url="http://127.0.0.1:23534", additional_headers=header)
+    client = weaviate.Client(url=MOCK_SERVER_URL, additional_headers=header)
     client.schema.delete_all()  # some call that includes headers
 
 
@@ -35,7 +36,7 @@ def test_additional_headers(weaviate_mock, header: Dict[str, str]):
 def test_warning_old_weaviate(recwarn, httpserver: HTTPServer, version: str, warning: bool):
     """Test that we warn if a new client version is using an old weaviate server."""
     httpserver.expect_request("/v1/meta").respond_with_json({"version": version})
-    weaviate.Client(url="http://127.0.0.1:23534")
+    weaviate.Client(url=MOCK_SERVER_URL)
 
     if warning:
         assert len(recwarn) == 1

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,0 +1,24 @@
+import pytest
+
+from weaviate import AuthBearerToken
+
+
+@pytest.mark.parametrize(
+    "expires_in,refresh_expires_in, warning",
+    [(-1, 5, True), (1, -5, True), (-9, -5, True), (5, 10, False)],
+)
+def test_bearer_validation(recwarn, expires_in: int, refresh_expires_in: int, warning: bool):
+    AuthBearerToken(
+        access_token="Doesn't matter",
+        refresh_token="Doesn't matter",
+        expires_in=expires_in,
+        refresh_expires_in=refresh_expires_in,
+    )
+
+    if warning:
+        assert len(recwarn) == 1
+        w = recwarn.pop()
+        assert issubclass(w.category, UserWarning)
+        assert str(w.message).startswith("Auth003")
+    else:
+        assert len(recwarn) == 0

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -3,16 +3,12 @@ import pytest
 from weaviate import AuthBearerToken
 
 
-@pytest.mark.parametrize(
-    "expires_in,refresh_expires_in, warning",
-    [(-1, 5, True), (1, -5, True), (-9, -5, True), (5, 10, False)],
-)
-def test_bearer_validation(recwarn, expires_in: int, refresh_expires_in: int, warning: bool):
+@pytest.mark.parametrize("expires_in,warning", [(-1, True), (5, False)])
+def test_bearer_validation(recwarn, expires_in: int, warning: bool):
     AuthBearerToken(
         access_token="Doesn't matter",
         refresh_token="Doesn't matter",
         expires_in=expires_in,
-        refresh_expires_in=refresh_expires_in,
     )
 
     if warning:

--- a/test/wcs/test_crud_wcs.py
+++ b/test/wcs/test_crud_wcs.py
@@ -7,53 +7,11 @@ from test.util import check_error_message, check_startswith_error_message
 from weaviate.auth import AuthClientPassword
 from weaviate.exceptions import (
     UnexpectedStatusCodeException,
-    AuthenticationFailedException,
 )
 from weaviate.wcs import WCS
 
 
 class TestWCS(unittest.TestCase):
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication")
-    def test___init__(self, mock_refresh_auth):
-        """
-        Test the `__init__` method.
-        """
-        # invalid calls
-        ## error messages
-        login_error_message = (
-            "No login credentials provided, or wrong type of credentials! "
-            "Accepted type of credentials: weaviate.auth.AuthClientPassword"
-        )
-
-        with self.assertRaises(AuthenticationFailedException) as error:
-            WCS(None)
-        check_error_message(self, error, login_error_message)
-        mock_refresh_auth.assert_not_called()
-
-        # valid calls
-        # without DEV
-        auth = AuthClientPassword("test_user", "test_pass")
-        wcs = WCS(auth)
-        self.assertTrue(wcs._oidc_auth_flow)
-        self.assertEqual(wcs.timeout_config, (2, 20))
-        self.assertEqual(wcs._auth_expires, 0)
-        self.assertIsNone(wcs._auth_bearer)
-        self.assertEqual(wcs._auth_client_secret, auth)
-        self.assertEqual(wcs.url, "https://wcs.api.semi.technology")
-        mock_refresh_auth.assert_called_with()
-
-        # without DEV
-        auth = AuthClientPassword("test_user", "test_pass")
-        wcs = WCS(auth, dev=True)
-        self.assertTrue(wcs._oidc_auth_flow)
-        self.assertEqual(wcs.timeout_config, (2, 20))
-        self.assertEqual(wcs._auth_expires, 0)
-        self.assertIsNone(wcs._auth_bearer)
-        self.assertEqual(wcs._auth_client_secret, auth)
-        self.assertEqual(wcs.url, "https://dev.wcs.api.semi.technology")
-        mock_refresh_auth.assert_called_with()
-
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.get_cluster_config")
     def test_is_ready(self, mock_get_cluster_config):
         """Test the `is_ready` method."""
@@ -77,7 +35,6 @@ class TestWCS(unittest.TestCase):
         self.assertEqual(wcs.is_ready("test_name2"), True)
         mock_get_cluster_config.assert_called_with("test_name2")
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.post")
     @patch("weaviate.wcs.crud_wcs.WCS.get_cluster_config")
     def test_create(self, mock_get_cluster_config, mock_post):
@@ -282,14 +239,11 @@ class TestWCS(unittest.TestCase):
         )
         self.assertEqual(result, "https://weaviate.semi.network")
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.get")
     def test_get_clusters(self, mock_get):
         """Test the `get_clusters` method."""
 
         wcs = WCS(AuthClientPassword("test@semi.technology", "testPassoword"))
-        wcs._auth_bearer = "test_bearer"
-
         # invalid calls
 
         ## error messages
@@ -319,7 +273,6 @@ class TestWCS(unittest.TestCase):
         self.assertEqual(result, "test!")
         mock_get.assert_called_with(path="/clusters/list", params={"email": "test@semi.technology"})
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.get")
     def test_get_cluster_config(self, mock_get):
         """Test the `get_cluster_config` method."""
@@ -379,7 +332,6 @@ class TestWCS(unittest.TestCase):
             path="/clusters/test_name",
         )
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.delete")
     def test_delete_cluster(self, mock_delete):
         """Test the `delete_cluster` method."""
@@ -431,7 +383,6 @@ class TestWCS(unittest.TestCase):
             path="/clusters/test_name",
         )
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.get")
     def test_get_users_of_cluster(self, mock_get):
         """
@@ -480,7 +431,6 @@ class TestWCS(unittest.TestCase):
             path="/clusters/test_name/users",
         )
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.post")
     def test_add_user_to_cluster(self, mock_post):
         """
@@ -532,7 +482,6 @@ class TestWCS(unittest.TestCase):
             weaviate_object=None,
         )
 
-    @patch("weaviate.wcs.crud_wcs.WCS._refresh_authentication", Mock())
     @patch("weaviate.wcs.crud_wcs.WCS.delete")
     def test_remove_user_from_cluster(self, mock_delete):
         """

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     "Client",
     "AuthClientCredentials",
     "AuthClientPassword",
-    "AuthBearerConfig",
+    "AuthBearerToken",
     "UnexpectedStatusCodeException",
     "ObjectAlreadyExistsException",
     "AuthenticationFailedException",
@@ -45,7 +45,7 @@ __all__ = [
 
 import sys
 
-from .auth import AuthClientCredentials, AuthClientPassword, AuthBearerConfig
+from .auth import AuthClientCredentials, AuthClientPassword, AuthBearerToken
 from .client import Client
 from .exceptions import (
     UnexpectedStatusCodeException,

--- a/weaviate/auth.py
+++ b/weaviate/auth.py
@@ -36,22 +36,19 @@ class AuthClientPassword:
 class AuthBearerToken:
     """Using a preexisting bearer/access token for authentication.
 
-    Only the access token is required. However, when no refresh token is supplied, the authentication will expire once
-    the lifetime of the access token is up.
+    The expiration time of access tokens is given in seconds.
 
-    The expiration time of access and refresh tokens are given in seconds.
+    Only the access token is required. However, when no refresh token is given, the authentication will expire once
+    the lifetime of the access token is up.
     """
 
     access_token: str
     expires_in: int = 60
     refresh_token: Optional[str] = None
-    refresh_expires_in: Optional[int] = None
 
     def __post_init__(self):
-        if (self.expires_in and self.expires_in < 0) or (
-            self.refresh_expires_in is not None and self.refresh_expires_in < 0
-        ):
-            _Warnings.auth_negative_expiration_time(self.expires_in, self.refresh_expires_in)
+        if self.expires_in and self.expires_in < 0:
+            _Warnings.auth_negative_expiration_time(self.expires_in)
 
 
 AuthCredentials = Union[AuthBearerToken, AuthClientPassword, AuthClientCredentials]

--- a/weaviate/auth.py
+++ b/weaviate/auth.py
@@ -9,7 +9,7 @@ from weaviate.warnings import _Warnings
 
 @dataclass
 class AuthClientCredentials:
-    """Authenticate for the client credential flow using client secrets.
+    """Authenticate for the Client Credential flow using client secrets.
 
     Acquire the client secret from your identify provider and set the appropriate scope. The client includes hardcoded
     scopes for Azure, otherwise it needs to be supplied.
@@ -21,7 +21,7 @@ class AuthClientCredentials:
 
 @dataclass
 class AuthClientPassword:
-    """Using username and password for authentication. In case of grant type password.
+    """Using username and password for authentication with Resource Owner Password flow.
 
     For some providers the scope needs to contain "offline_access" (and "openid" which is automatically added) to return
     a refresh token. Without a refresh token the authentication will expire once the lifetime of the access token is up.

--- a/weaviate/auth.py
+++ b/weaviate/auth.py
@@ -2,16 +2,11 @@
 Authentication class definitions.
 """
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 
 @dataclass
-class AuthCredentials:
-    """Base class for authentication."""
-
-
-@dataclass
-class AuthClientCredentials(AuthCredentials):
+class AuthClientCredentials:
     """Authenticate for the client credential flow using client secrets.
 
     Acquire the client secret from your identify provider and set the appropriate scope. Rhe client includes hardcoded
@@ -23,15 +18,22 @@ class AuthClientCredentials(AuthCredentials):
 
 
 @dataclass
-class AuthClientPassword(AuthCredentials):
+class AuthClientPassword:
     """Using username and password for authentication. In case of grant type password."""
 
     username: str
     password: str
+    scope: Optional[str] = "offline_access"
 
 
 @dataclass
-class AuthBearerConfig(AuthCredentials):
+class AuthBearerToken:
     """Using a preexisting bearer token for authentication."""
 
     bearer_token: str
+    expires_in: Optional[int] = None
+    refresh_token: Optional[str] = None
+    refresh_expires_in: Optional[int] = None
+
+
+AuthCredentials = Union[AuthBearerToken, AuthClientPassword, AuthClientCredentials]

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -61,7 +61,10 @@ class Client:
         url : str
             The URL to the weaviate instance.
         auth_client_secret : weaviate.AuthCredentials or None, optional
-            Authentication client secret, by default None.
+            Authenticate to weaviate by using one of the given authentication modes:
+            - weaviate.auth.AuthBearerToken to use existing access and (optionally, but recommended) refresh tokens
+            - weaviate.auth.AuthClientPassword to use username and password for oidc Resource Owner Password flow
+            - weaviate.auth.AuthClientCredentials to use a client secret for oidc client credential flow
         timeout_config : tuple(Real, Real) or Real, optional
             Set the timeout configuration for all requests to the Weaviate server. It can be a
             real number or, a tuple of two real numbers: (connect timeout, read timeout).
@@ -79,10 +82,8 @@ class Client:
             NOTE: 'proxies' has priority over 'trust_env', i.e. if 'proxies' is NOT None,
             'trust_env' is ignored.
         additional_headers : dict or None
-            Additional headers to include in the requests. You can set a bearer token to
-            authenticate directly to Weaviate by setting the additional headers like this:
-                {"authorization": "Bearer <MY_TOKEN>"}
-            And/or used to set OpenAI/HuggingFace key. OpenAI/HuggingFace key looks like this:
+            Additional headers to include in the requests.
+            Can be used to set OpenAI/HuggingFace keys. OpenAI/HuggingFace key looks like this:
                 {"X-OpenAI-Api-Key": "<THE-KEY>"}, {"X-HuggingFace-Api-Key": "<THE-KEY>"}
             by default None
 

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -54,9 +54,6 @@ class _Auth:
         response_auth = requests.get(self._open_id_config_url, proxies=self._connection.proxies)
         return response_auth.json()["token_endpoint"]
 
-    def get_token_endpoint(self) -> str:
-        return self._token_endpoint
-
     def get_auth_session(self) -> OAuth2Session:
         if isinstance(self._auth_config, AuthBearerToken):
             session = self._get_session_auth_bearer_token(self._auth_config)
@@ -107,8 +104,7 @@ class _Auth:
                 scope = self._client_id + "/.default"
             else:
                 raise MissingScopeException
-
-        return OAuth2Session(
+        session = OAuth2Session(
             client_id=self._client_id,
             client_secret=config.client_secret,
             token_endpoint_auth_method="client_secret_post",
@@ -117,3 +113,6 @@ class _Auth:
             grant_type="client_credentials",
             token={"access_token": None, "expires_in": -100},
         )
+        # explicitly fetch tokens. Otherwise authlib will do it in the background and we might have race-conditions
+        session.fetch_token()
+        return session

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -113,6 +113,6 @@ class _Auth:
             grant_type="client_credentials",
             token={"access_token": None, "expires_in": -100},
         )
-        # explicitly fetch tokens. Otherwise authlib will do it in the background and we might have race-conditions
+        # explicitly fetch tokens. Otherwise, authlib will do it in the background and we might have race-conditions
         session.fetch_token()
         return session

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -71,8 +71,6 @@ class _Auth:
             token["expires_in"] = config.expires_in
         if config.refresh_token is not None:
             token["refresh_token"] = config.refresh_token
-        if config.refresh_expires_in is not None:
-            token["refresh_expires_in"] = config.refresh_expires_in
 
         if "refresh_token" not in token:
             _Warnings.auth_no_refresh_token(config.expires_in)

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -69,7 +69,7 @@ class _Auth:
         return session
 
     def _get_session_auth_bearer_token(self, config: AuthBearerToken) -> OAuth2Session:
-        token = {"access_token": config.bearer_token}
+        token = {"access_token": config.access_token}
         if config.expires_in is not None:
             token["expires_in"] = config.expires_in
         if config.refresh_token is not None:

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
+from typing import Dict
 from typing import TYPE_CHECKING
-from typing import Tuple, Dict
 
 import requests
 from authlib.integrations.requests_client import OAuth2Session
-from requests import RequestException
 
 from weaviate.auth import (
     AuthCredentials,
     AuthClientPassword,
-    AuthBearerConfig,
+    AuthBearerToken,
     AuthClientCredentials,
 )
 from weaviate.exceptions import MissingScopeException, AuthenticationFailedException
+from ..warnings import _Warnings
 
 if TYPE_CHECKING:
     from . import BaseConnection
@@ -51,61 +51,69 @@ class _Auth:
                 )
 
     def _get_token_endpoint(self) -> str:
-        response_auth = self._connection.get(self._open_id_config_url, external_url=True)
+        response_auth = requests.get(self._open_id_config_url, proxies=self._connection.proxies)
         return response_auth.json()["token_endpoint"]
 
-    def get_auth_token(self) -> Tuple[str, int]:
-        if isinstance(self._auth_config, AuthBearerConfig):
-            return self._auth_config.bearer_token, 1
+    def get_token_endpoint(self) -> str:
+        return self._token_endpoint
+
+    def get_auth_session(self) -> OAuth2Session:
+        if isinstance(self._auth_config, AuthBearerToken):
+            session = self._get_session_auth_bearer_token(self._auth_config)
         elif isinstance(self._auth_config, AuthClientCredentials):
-            return self._get_token_client_credential(self._token_endpoint, self._auth_config)
+            session = self._get_session_client_credential(self._auth_config)
         else:
             assert isinstance(self._auth_config, AuthClientPassword)
-            return self._get_token_user_pw(self._token_endpoint, self._auth_config)
+            session = self._get_session_user_pw(self._auth_config)
 
-    def _get_token_user_pw(self, token_endpoint: str, config: AuthClientPassword):
-        request_body = {
-            "grant_type": "password",
-            "client_id": self._client_id,
-            "username": config.username,
-            "password": config.password,
-        }
-        try:
-            request = requests.post(
-                token_endpoint,
-                request_body,
-                proxies=self._connection.proxies,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-        except RequestException:
-            raise AuthenticationFailedException(
-                "Unable to get a OAuth token from server. Are the credentials and URLs correct?"
-            )
-        if request.status_code == 401:
-            raise AuthenticationFailedException(
-                "Authentication access denied. Are the credentials correct?"
-            )
-        token = request.json()
-        return token["access_token"], token["expires_in"]
+        return session
 
-    def _get_token_client_credential(self, token_endpoint: str, config: AuthClientCredentials):
+    def _get_session_auth_bearer_token(self, config: AuthBearerToken) -> OAuth2Session:
+        token = {"access_token": config.bearer_token}
+        if config.expires_in is not None:
+            token["expires_in"] = config.expires_in
+        if config.refresh_token is not None:
+            token["refresh_token"] = config.refresh_token
+        if config.refresh_expires_in is not None:
+            token["refresh_expires_in"] = config.refresh_expires_in
+
+        if "refresh_token" not in token:
+            _Warnings.auth_no_refresh_token(config.expires_in)
+
+        # token endpoint and clientId are needed for token refresh
+        return OAuth2Session(
+            token=token, token_endpoint=self._token_endpoint, client_id=self._client_id
+        )
+
+    def _get_session_user_pw(self, config: AuthClientPassword) -> OAuth2Session:
+        session = OAuth2Session(
+            client_id=self._client_id,
+            token_endpoint=self._token_endpoint,
+            grant_type="password",
+            scope=config.scope,
+        )
+        token = session.fetch_token(username=config.username, password=config.password)
+        if "refresh_token" not in token:
+            _Warnings.auth_no_refresh_token(token["expires_in"])
+
+        return session
+
+    def _get_session_client_credential(self, config: AuthClientCredentials) -> OAuth2Session:
         if config.scope is not None:
             scope = config.scope
         else:
             # hardcode commonly used scopes
-            if token_endpoint.startswith("https://login.microsoftonline.com"):
+            if self._token_endpoint.startswith("https://login.microsoftonline.com"):
                 scope = self._client_id + "/.default"
             else:
                 raise MissingScopeException
 
-        session = OAuth2Session(
+        return OAuth2Session(
             client_id=self._client_id,
             client_secret=config.client_secret,
             token_endpoint_auth_method="client_secret_post",
             scope=scope,
-            token_endpoint=token_endpoint,
+            token_endpoint=self._token_endpoint,
             grant_type="client_credentials",
             token={"access_token": None, "expires_in": -100},
         )
-        token = session.fetch_token()
-        return token["access_token"], token["expires_in"]

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -89,7 +89,7 @@ class BaseConnection:
 
         if "authorization" in self._headers:
             bearer_header = self._headers["authorization"]
-            auth_client_secret = auth.AuthBearerToken(bearer_token=bearer_header)
+            auth_client_secret = auth.AuthBearerToken(access_token=bearer_header)
 
         self._auth: Optional[_Auth] = None
         self._session: Session = self._create_session(auth_client_secret)

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -92,7 +92,6 @@ class BaseConnection:
             auth_client_secret = auth.AuthBearerToken(bearer_token=bearer_header)
 
         self._auth: Optional[_Auth] = None
-        self
         self._session: Session = self._create_session(auth_client_secret)
 
         # while the underlying library refreshes tokens, it does not have an internal cronjob that checks every

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -87,9 +87,14 @@ class BaseConnection:
 
         self._proxies = _get_proxies(proxies, trust_env)
 
-        if "authorization" in self._headers:
+        # auth secrets can contain more information than a header (refresh tokens and lifetime) and therefore take
+        # precedent over headers
+        if "authorization" in self._headers and auth_client_secret is None:
             bearer_header = self._headers["authorization"]
             auth_client_secret = auth.AuthBearerToken(access_token=bearer_header)
+        elif "authorization" in self._headers and auth_client_secret is not None:
+            _Warnings.auth_header_and_auth_secret()
+            self._headers.pop("authorization")
 
         self._background_thread: Optional[Thread] = None
         self._session: Session

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -36,12 +36,8 @@ class _Warnings:
         )
 
     @staticmethod
-    def auth_negative_expiration_time(expires_in: int, refresh_expires_in: Optional[int]):
-        msg = """Auth003:"""
-        if expires_in < 0:
-            msg += f"access token expiration time is negative: {expires_in}."
-        if refresh_expires_in < 0:
-            msg += f"refresh token expiration time is negative: {refresh_expires_in}."
+    def auth_negative_expiration_time(expires_in: int):
+        msg = f"""Auth003: Access token expiration time is negative: {expires_in}."""
 
         warnings.warn(message=msg, category=UserWarning, stacklevel=1)
 

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -43,11 +43,17 @@ class _Warnings:
         if refresh_expires_in < 0:
             msg += f"refresh token expiration time is negative: {refresh_expires_in}."
 
-        warnings.warn(
-            message=msg,
-            category=UserWarning,
-            stacklevel=1,
-        )
+        warnings.warn(message=msg, category=UserWarning, stacklevel=1)
+
+    @staticmethod
+    def auth_header_and_auth_secret():
+        msg = """Auth004: Received an authentication header and an auth_client_secret parameter.
+
+         The auth_client_secret takes precedence over the header and the authentication header will be ignored. Use
+         weaviate.auth.AuthBearerToken(..) to supply an access token via auth_client_secret parameter and (if available)
+         also supply refresh tokens and token lifetimes.
+         """
+        warnings.warn(message=msg, category=UserWarning, stacklevel=1)
 
     @staticmethod
     def weaviate_server_older_than_1_14(server_version: str):

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Optional
 
 import weaviate.version as version
 
@@ -9,6 +10,27 @@ class _Warnings:
         warnings.warn(
             message="""Auth001: The client was configured to use authentication, but weaviate is configured without
                     authentication. Are you sure this is correct?""",
+            category=UserWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
+    def auth_no_refresh_token(auth_len: Optional[int] = None):
+        if auth_len is not None:
+            msg = f"The current access token is only valid for {auth_len}s."
+        else:
+            msg = "Also, no expiration time was given."
+
+        warnings.warn(
+            message=f"""Auth002: The token returned from you identity provider does not contain a refresh token. {msg}
+
+            Access to your weaviate instance is not possible after expiration and this client will return an
+            authentication exception.
+
+            Things to try:
+            - You might need to enable refresh tokens in the settings of your authentication provider
+            - You might need to send the correct scope. For some providers it needs to include "offline_access"
+            ?""",
             category=UserWarning,
             stacklevel=1,
         )

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -30,7 +30,21 @@ class _Warnings:
             Things to try:
             - You might need to enable refresh tokens in the settings of your authentication provider
             - You might need to send the correct scope. For some providers it needs to include "offline_access"
-            ?""",
+            """,
+            category=UserWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
+    def auth_negative_expiration_time(expires_in: int, refresh_expires_in: Optional[int]):
+        msg = """Auth003:"""
+        if expires_in < 0:
+            msg += f"access token expiration time is negative: {expires_in}."
+        if refresh_expires_in < 0:
+            msg += f"refresh token expiration time is negative: {refresh_expires_in}."
+
+        warnings.warn(
+            message=msg,
             category=UserWarning,
             stacklevel=1,
         )

--- a/weaviate/wcs/crud_wcs.py
+++ b/weaviate/wcs/crud_wcs.py
@@ -12,7 +12,6 @@ from weaviate.auth import AuthClientPassword
 from weaviate.connect.connection import BaseConnection
 from weaviate.exceptions import (
     UnexpectedStatusCodeException,
-    AuthenticationFailedException,
 )
 
 
@@ -82,24 +81,7 @@ class WCS(BaseConnection):
             trust_env=trust_env,
             additional_headers=None,
         )
-        self._oidc_auth_flow = True
-
-    def _log_in(self) -> None:
-        """
-        Log in to WCS.
-
-        Raises
-        ------
-        weaviate.AuthenticationFailedException
-            If no login credentials provided, or wrong type of credentials!
-        """
-        if isinstance(self._auth_client_secret, AuthClientPassword):
-            self._refresh_authentication()
-        else:
-            raise AuthenticationFailedException(
-                "No login credentials provided, or wrong type of credentials! "
-                "Accepted type of credentials: weaviate.auth.AuthClientPassword"
-            )
+        self._email = auth_client_secret.username
 
     def create(
         self,
@@ -320,10 +302,9 @@ class WCS(BaseConnection):
         """
 
         try:
-            assert isinstance(self._auth_client_secret, AuthClientPassword)
             response = self.get(
                 path="/clusters/list",
-                params={"email": self._auth_client_secret.username},
+                params={"email": self._email},
             )
         except RequestsConnectionError as conn_err:
             raise RequestsConnectionError("WCS clusters were not fetched.") from conn_err


### PR DESCRIPTION
Use authilb.Oauth2 sessions to manage authentication instead of adding a authorization header manually.

This has multiple advantages:
- Less requests where a body has to be created and a response parsed
- Oauth2 sessions acts like a request session while handling all the authentication in the backround
- You can refresh tokens using session.refresh_token(). So it is not needed to keep username and password in memory.

While oauth2 automatically refreshes tokens, it does not have an internal wake-up timer. In case the client idles longer than the lifetime of the refresh token, the authorization can time out. To circumvent this, I added a backround task that periodically refreshes the tokens.

Wit this change, I gave priority to the `auth_client_secret` parameter over the authentication header. As it is not possible to add refresh tokens there, `auth_client_secret` is better in all cases. 

I also had to delete some unit tests. They were testing the old implementation and there was no real way to transfer them over. I think long-term we need to replace these tests with tests that use a mock-server.